### PR TITLE
feat: add morgothctl restart command

### DIFF
--- a/src/morgothctl/CMakeLists.txt
+++ b/src/morgothctl/CMakeLists.txt
@@ -12,6 +12,7 @@ set (morgothctl_SOURCES
     consolecommand.h
     listcommand.h
     removecommand.h
+    restartcommand.h
     startcommand.h
     statuscommand.h
     stopcommand.h
@@ -21,6 +22,7 @@ set (morgothctl_SOURCES
     consolecommand.cpp
     listcommand.cpp
     removecommand.cpp
+    restartcommand.cpp
     startcommand.cpp
     statuscommand.cpp
     stopcommand.cpp

--- a/src/morgothctl/main.cpp
+++ b/src/morgothctl/main.cpp
@@ -20,6 +20,7 @@
 #include "listcommand.h"
 #include "morgothdaemon.h"
 #include "removecommand.h"
+#include "restartcommand.h"
 #include "startcommand.h"
 #include "statuscommand.h"
 #include "stopcommand.h"
@@ -65,7 +66,8 @@ int main(int argc, char** argv)
         new StopCommand,
         new StatusCommand,
         new ConfigCommand,
-        new ConsoleCommand
+        new ConsoleCommand,
+        new RestartCommand
     });
 
     QCommandLineParser parser;

--- a/src/morgothctl/restartcommand.cpp
+++ b/src/morgothctl/restartcommand.cpp
@@ -1,6 +1,31 @@
+// This file is part of morgoth.
+
+// morgoth is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #include "restartcommand.h"
+#include "startcommand.h"
+#include "stopcommand.h"
+#include <QtCore>
 
-RestartCommand::RestartCommand()
+int RestartCommand::execute(QDBusConnection dbus, const QStringList& arguments, QTextStream& out)
 {
-
+    StopCommand stop;
+    int res = stop.execute(dbus, arguments, out);
+    if (res == 0) {
+        StartCommand start;
+        return start.execute(dbus, arguments, out);
+    } else {
+        return res;
+    }
 }

--- a/src/morgothctl/restartcommand.cpp
+++ b/src/morgothctl/restartcommand.cpp
@@ -1,0 +1,6 @@
+#include "restartcommand.h"
+
+RestartCommand::RestartCommand()
+{
+
+}

--- a/src/morgothctl/restartcommand.h
+++ b/src/morgothctl/restartcommand.h
@@ -1,11 +1,29 @@
+// This file is part of morgoth.
+
+// morgoth is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #ifndef RESTARTCOMMAND_H
 #define RESTARTCOMMAND_H
 
+#include "morgothctlplugin.h"
 
-class RestartCommand
-{
+class RestartCommand : public morgoth::MorgothCtlPlugin {
 public:
-    RestartCommand();
+    QString command() const override { return "restart"; }
+
+    int execute(QDBusConnection dbus, const QStringList& arguments,
+                QTextStream& out) override;
 };
 
 #endif // RESTARTCOMMAND_H

--- a/src/morgothctl/restartcommand.h
+++ b/src/morgothctl/restartcommand.h
@@ -1,0 +1,11 @@
+#ifndef RESTARTCOMMAND_H
+#define RESTARTCOMMAND_H
+
+
+class RestartCommand
+{
+public:
+    RestartCommand();
+};
+
+#endif // RESTARTCOMMAND_H

--- a/src/morgothctl/startcommand.cpp
+++ b/src/morgothctl/startcommand.cpp
@@ -85,7 +85,7 @@ int StartCommand::execute(QDBusConnection dbus, const QStringList& arguments, QT
         Q_ASSERT(server.isValid());
 
         org::morgoth::ServerCoordinator coordinator(morgoth::MorgothDaemon::dbusServiceName(), server.coordinatorPath().path(), dbus);
-        if (coordinator.state() != morgoth::ServerCoordinator::Offline) {
+        if (!(coordinator.state() == morgoth::ServerCoordinator::Offline || coordinator.state() == morgoth::ServerCoordinator::Crashed)) {
             out << "Server " << serverName << " is already running" << endl;
             return 0;
         }


### PR DESCRIPTION
Implements the `morgothctl restart` command that restarts the given game server.
Closes #1 